### PR TITLE
Update list of Image MIME-Types

### DIFF
--- a/SIP/sip-44.md
+++ b/SIP/sip-44.md
@@ -182,12 +182,14 @@ The profile information can be extended by any data by means of the `xt` field. 
 
 For the `av` and `bg` field additional information of the [images MIME-Type](https://mimetype.io/all-types/#image) is required. At least supported image types SHOULD be:
 
+- `image/apng`
+- `image/avif`
 - `image/jpeg`
+- `image/jpg`
 - `image/png`
 - `image/webp`
 - `image/gif`
 - `image/svg+xml`
-
 
 ### URIs
 


### PR DESCRIPTION
I am updating the list of Image MIME-Types, some of the were missing.
The new ones to add are the following:
- `image/apng`
- `image/avif`
- `image/jpg`